### PR TITLE
Option type conversion

### DIFF
--- a/main/main/Option.java
+++ b/main/main/Option.java
@@ -29,10 +29,6 @@ public record Option<T>(Type type, Set<String> names, Class<T> valueType, Functi
     Type(Object defaultValue) {
       this.defaultValue = defaultValue;
     }
-
-    Object defaultValue(Option<?> of) {
-      return this == VARARGS ? (Object[]) Array.newInstance(of.valueType(), 0) : defaultValue;
-    }
   }
 
   public Option {
@@ -83,6 +79,10 @@ public record Option<T>(Type type, Set<String> names, Class<T> valueType, Functi
 
   public T create(String value) {
     return toValue().apply(value);
+  }
+
+  Object defaultValue() {
+    return type() == Type.VARARGS ? (Object[]) Array.newInstance(valueType(), 0) : type().defaultValue;
   }
 
   private static Set<String> checkDuplicates(String... names) {

--- a/main/main/Schema.java
+++ b/main/main/Schema.java
@@ -72,7 +72,7 @@ public class Schema<T> {
       for (var name : option.names()) {
         optionsByName.put(name, option);
       }
-      workspace.put(option.name(), option.type().defaultValue());
+      workspace.put(option.name(), option.type().defaultValue(option));
     }
 
     while (true) {

--- a/main/main/Schema.java
+++ b/main/main/Schema.java
@@ -72,7 +72,7 @@ public class Schema<T> {
       for (var name : option.names()) {
         optionsByName.put(name, option);
       }
-      workspace.put(option.name(), option.type().defaultValue(option));
+      workspace.put(option.name(), option.defaultValue());
     }
 
     while (true) {

--- a/main/main/Splitter.java
+++ b/main/main/Splitter.java
@@ -22,7 +22,7 @@ public interface Splitter<T> {
     return of(RecordSchemaSupport.toSchema(lookup, schema));
   }
 
-  static Splitter<Map<String, Value>> of(Option... options) {
+  static Splitter<Map<String, Value<?>>> of(Option<?>... options) {
     requireNonNull(options, "options is null");
     return of(Value.toSchema(options));
   }

--- a/main/main/Value.java
+++ b/main/main/Value.java
@@ -10,17 +10,17 @@ import java.util.Optional;
 
 public sealed interface Value {
 
-  Option option();
+  Option<?> option();
 
-  record FlagValue(Option option, boolean value) implements Value {}
+  record FlagValue(Option<?> option, boolean value) implements Value {}
 
-  record SingleValue(Option option, Optional<String> value) implements Value {}
+  record SingleValue(Option<?> option, Optional<String> value) implements Value {}
 
-  record RepeatableValue(Option option, List<String> value) implements Value {}
+  record RepeatableValue(Option<?> option, List<String> value) implements Value {}
 
-  record RequiredValue(Option option, String value) implements Value {}
+  record RequiredValue(Option<?> option, String value) implements Value {}
 
-  record VarargsValue(Option option, String... value) implements Value {
+  record VarargsValue(Option<?> option, String... value) implements Value {
     @Override
     public boolean equals(Object obj) {
       return obj instanceof VarargsValue other
@@ -34,12 +34,12 @@ public sealed interface Value {
     }
   }
 
-  static Schema<Map<String, Value>> toSchema(Option... options) {
+  static Schema<Map<String, Value>> toSchema(Option<?>... options) {
     var list = List.of(options);
     return new Schema<>(list, values -> evaluate(list, values));
   }
 
-  private static Map<String, Value> evaluate(List<Option> options, Collection<Object> collection) {
+  private static Map<String, Value> evaluate(List<? extends Option<?>> options, Collection<Object> collection) {
     assert options.size() != collection.size() : "size mismatch";
     var objects = List.copyOf(collection);
     var values = new LinkedHashMap<String, Value>();
@@ -54,7 +54,7 @@ public sealed interface Value {
   }
 
   @SuppressWarnings("unchecked")
-  private static Value evaluate(Option option, Object object) {
+  private static Value evaluate(Option<?> option, Object object) {
     if (object instanceof Boolean value)
       return value /* == true */ ? new FlagValue(option, value) : null;
     if (object instanceof Optional<?> value)

--- a/test/test/EnumTests.java
+++ b/test/test/EnumTests.java
@@ -36,12 +36,12 @@ class EnumTests {
   // ---
 
   public static final class ArgumentBag<K> {
-    private final List<Option> options;
+    private final List<? extends Option<?>> options;
     private final List<Object> data;
-    private final Function<List<Option>, Map<K, Integer>> indexMapFactory;
+    private final Function<List<? extends Option<?>>, Map<K, Integer>> indexMapFactory;
     private Map<K, Integer> indexMap;  // lazy
 
-    private ArgumentBag(List<Option> options, List<Object> data, Function<List<Option>, Map<K, Integer>> indexMapFactory) {
+    private ArgumentBag(List<? extends Option<?>> options, List<Object> data, Function<List<? extends Option<?>>, Map<K, Integer>> indexMapFactory) {
       this.options = options;
       this.data = data;
       this.indexMapFactory = indexMapFactory;
@@ -127,7 +127,7 @@ class EnumTests {
     }
   }
 
-  public static Schema<ArgumentBag<String>> schemaArgument(Option... options) {
+  public static Schema<ArgumentBag<String>> schemaArgument(Option<?>... options) {
     requireNonNull(options, "options is null");
     var opt = List.of(options);
     return new Schema<>(opt, data -> new ArgumentBag<>(opt, data,
@@ -135,16 +135,16 @@ class EnumTests {
   }
 
   public interface Configuration<K> {
-    Configuration<K> with(K key, Option option);
+    Configuration<K> with(K key, Option<?> option);
   }
 
   public static <K> Schema<ArgumentBag<K>> schemaKeyed(Consumer<? super Configuration<K>> consumer)  {
     requireNonNull(consumer, "consumer is null");
     var keys = new ArrayList<K>();
-    var options = new ArrayList<Option>();
+    var options = new ArrayList<Option<?>>();
     consumer.accept(new Configuration<>() {
       @Override
-      public Configuration<K> with(K key, Option option) {
+      public Configuration<K> with(K key, Option<?> option) {
         requireNonNull(key, "key is null");
         requireNonNull(option, "option is null");
         keys.add(key);

--- a/test/test/EnumTests.java
+++ b/test/test/EnumTests.java
@@ -165,23 +165,23 @@ class EnumTests {
     }
 
     public static Parameter<Boolean> flag(String... names) {
-      return new Parameter<>(FLAG.option(names));
+      return new Parameter<>(Option.ofFlag(names));
     }
 
     public static Parameter<Optional<String>> single(String... names) {
-      return new Parameter<>(SINGLE.option(names));
+      return new Parameter<>(Option.ofSingle(names));
     }
 
     public static Parameter<String> required(String... names) {
-      return new Parameter<>(REQUIRED.option(names));
+      return new Parameter<>(Option.ofRequired(names));
     }
 
     public static Parameter<List<String>> repeatable(String... names) {
-      return new Parameter<>(REPEATABLE.option(names));
+      return new Parameter<>(Option.ofRepeatable(names));
     }
 
     public static Parameter<String[]> varargs(String... names) {
-      return new Parameter<>(VARARGS.option(names));
+      return new Parameter<>(Option.ofVarargs(names));
     }
 
     @Override
@@ -233,9 +233,9 @@ class EnumTests {
   @Test
   void stringArguments() {
     var schema = EnumTests.schemaKeyed(conf -> conf
-        .with("optionFlag", FLAG.option("-f", "--flag"))
-        .with("optionText", SINGLE.option("-t", "--text"))
-        .with("optionR", REQUIRED.option("-r")));
+        .with("optionFlag", Option.ofFlag("-f", "--flag"))
+        .with("optionText", Option.ofSingle("-t", "--text"))
+        .with("optionR", Option.ofRequired("-r")));
     var argumentBag = Splitter.of(schema).split("-f", "value");
 
     assertTrue(argumentBag.flag("optionFlag"));
@@ -248,9 +248,9 @@ class EnumTests {
     enum Value { F, TEXT, R }
 
     var schema = schemaKeyed(conf -> conf
-        .with(Value.F, FLAG.option("-f", "--flag"))
-        .with(Value.TEXT, SINGLE.option("-t", "--text"))
-        .with(Value.R, REQUIRED.option("-r")));
+        .with(Value.F, Option.ofFlag("-f", "--flag"))
+        .with(Value.TEXT, Option.ofSingle("-t", "--text"))
+        .with(Value.R, Option.ofRequired("-r")));
     var argumentBag = Splitter.of(schema).split("-f", "value");
 
     assertTrue(argumentBag.flag(Value.F));
@@ -261,9 +261,9 @@ class EnumTests {
   @Test
   void optionsArgument() {
     var schema = EnumTests.schemaArgument(
-        FLAG.option("-f", "--flag"),
-        SINGLE.option("-t", "--text"),
-        REQUIRED.option("-r"));
+            Option.ofFlag("-f", "--flag"),
+            Option.ofSingle("-t", "--text"),
+            Option.ofRequired("-r"));
     var argumentBag = Splitter.of(schema).split("-f", "value");
 
     assertTrue(argumentBag.flagAt(0));

--- a/test/test/EnumTests.java
+++ b/test/test/EnumTests.java
@@ -158,9 +158,9 @@ class EnumTests {
 
 
   public static final class Parameter<T> {
-    private final Option option;
+    private final Option<?> option;
 
-    private Parameter(Option option) {
+    private Parameter(Option<?> option) {
       this.option = option;
     }
 

--- a/test/test/ValueTests.java
+++ b/test/test/ValueTests.java
@@ -5,7 +5,11 @@ import static main.Option.Type.REQUIRED;
 import static main.Option.Type.SINGLE;
 import static test.api.Assertions.assertEquals;
 
+import java.nio.file.Path;
 import java.util.Map;
+import java.util.function.Function;
+
+import main.Option;
 import main.Splitter;
 import main.Value;
 import test.api.JTest;
@@ -18,15 +22,15 @@ class ValueTests {
 
   @Test
   void test() {
-    var flag = FLAG.option("-f", "--flag");
-    var text = SINGLE.option("-t", "--text");
-    var required = REQUIRED.option("-r");
+    var flag = Option.ofFlag("-f", "--flag");
+    var text = Option.ofSingle( "-t", "--text");
+    var required = Option.ofRequired(Path.class, Path::of, "-r");
 
-    Map<String, Value> values = Splitter.of(flag, text, required).split("-f", "value");
+    Map<String, Value<?>> values = Splitter.of(flag, text, required).split("-f", "value");
     assertEquals(new Value.FlagValue(flag, true), values.get("-f"));
     assertEquals(new Value.FlagValue(flag, true), values.get("--flag"));
     assertEquals(null, values.get("-t"));
     assertEquals(null, values.get("--text"));
-    assertEquals(new Value.RequiredValue(required, "value"), values.get("-r"));
+    assertEquals(new Value.RequiredValue(required, Path.of("value")), values.get("-r"));
   }
 }

--- a/test/test/jdk/JarRecordTests.java
+++ b/test/test/jdk/JarRecordTests.java
@@ -4,6 +4,9 @@ import static java.lang.invoke.MethodHandles.lookup;
 import static test.api.Assertions.assertEquals;
 import static test.api.Assertions.assertEqualsOptional;
 
+import java.nio.file.Path;
+import java.time.ZonedDateTime;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import main.Name;
@@ -37,16 +40,16 @@ public class JarRecordTests {
       @Name("--hash-modules") Optional<String> hashModules,
       @Name({"-p", "--module-path"}) Optional<String> modulePath,
       @Name({"-0", "--no-compress"}) boolean noCompress,
-      @Name("--date") Optional<String> date,
+      @Name("--date") Optional<ZonedDateTime> date,
       @Name({"-?", "-h", "--help"}) boolean help,
       @Name("--help:compat") boolean helpCompat,
       @Name("--help-extra") boolean helpExtra,
       @Name("--version") boolean version,
       String... files) {
 
-    record ChangeDirOptions(String dir, String file) {}
+    record ChangeDirOptions(String dir, Path file) {}
 
-    record ReleaseOptions(String version, @Name("-C") List<ChangeDirOptions> Cs) {}
+    record ReleaseOptions(Integer version, @Name("-C") List<ChangeDirOptions> Cs) {}
   }
 
   private static JarOptions splitInput(String line) {
@@ -67,7 +70,7 @@ public class JarRecordTests {
         splitInput(
             "--create --date=\"2021-01-06T14:36:00+02:00\" --file=classes.jar Foo.class Bar.class");
     assertEquals(true, options.create());
-    assertEqualsOptional("\"2021-01-06T14:36:00+02:00\"", options.date());
+    assertEqualsOptional(ZonedDateTime.parse("2021-01-06T14:36:00+02:00"), options.date());
     assertEqualsOptional("classes.jar", options.file());
     assertEquals(List.of("Foo.class", "Bar.class"), List.of(options.files()));
   }
@@ -78,7 +81,7 @@ public class JarRecordTests {
     assertEquals(true, options.create());
     assertEqualsOptional("classes.jar", options.file());
     assertEqualsOptional("mymanifest", options.manifest());
-    assertEqualsOptional(new ChangeDirOptions("foo/", "."), options.changeDir());
+    assertEqualsOptional(new ChangeDirOptions("foo/", Path.of(".")), options.changeDir());
   }
 
   @Test
@@ -93,7 +96,7 @@ public class JarRecordTests {
     assertEqualsOptional("1.0", options.moduleVersion());
     var cOptions = options.changeDir().orElseThrow();
     assertEquals("foo/classes", cOptions.dir());
-    assertEquals("resources", cOptions.file());
+    assertEquals(Path.of("resources"), cOptions.file());
   }
 
   @Test
@@ -106,9 +109,9 @@ public class JarRecordTests {
     assertEquals(true, options.create());
     assertEqualsOptional("foo.jar", options.file());
     assertEqualsOptional("com.foo.Hello", options.mainClass());
-    assertEqualsOptional(new ChangeDirOptions("classes", "."), options.changeDir());
+    assertEqualsOptional(new ChangeDirOptions("classes", Path.of(".")), options.changeDir());
     assertEqualsOptional(
-        new ReleaseOptions("10", List.of(new ChangeDirOptions("classes-10", "."))),
+        new ReleaseOptions(10, List.of(new ChangeDirOptions("classes-10", Path.of(".")))),
         options.release());
   }
 }

--- a/test/test/jdk/JarRecordTests.java
+++ b/test/test/jdk/JarRecordTests.java
@@ -45,7 +45,7 @@ public class JarRecordTests {
       @Name("--help:compat") boolean helpCompat,
       @Name("--help-extra") boolean helpExtra,
       @Name("--version") boolean version,
-      String... files) {
+      Path... files) {
 
     record ChangeDirOptions(String dir, Path file) {}
 
@@ -61,7 +61,7 @@ public class JarRecordTests {
     var options = splitInput("--create --file classes.jar Foo.class Bar.class");
     assertEquals(true, options.create());
     assertEqualsOptional("classes.jar", options.file());
-    assertEquals(List.of("Foo.class", "Bar.class"), List.of(options.files()));
+    assertEquals(List.of(Path.of("Foo.class"), Path.of( "Bar.class")), List.of(options.files()));
   }
 
   @Test
@@ -72,7 +72,7 @@ public class JarRecordTests {
     assertEquals(true, options.create());
     assertEqualsOptional(ZonedDateTime.parse("2021-01-06T14:36:00+02:00"), options.date());
     assertEqualsOptional("classes.jar", options.file());
-    assertEquals(List.of("Foo.class", "Bar.class"), List.of(options.files()));
+    assertEquals(List.of(Path.of("Foo.class"), Path.of("Bar.class")), List.of(options.files()));
   }
 
   @Test

--- a/test/test/jdk/JarValueTests.java
+++ b/test/test/jdk/JarValueTests.java
@@ -20,9 +20,9 @@ public class JarValueTests {
     JTest.runTests(new JarValueTests(), args);
   }
 
-  static final Option CREATE_FLAG = FLAG.option("-c", "--create").withHelp("Create an archive");
-  static final Option FILE_OPTION = SINGLE.option("-f", "--file").withHelp("The archive file");
-  static final Option[] OPTIONS = {CREATE_FLAG, FILE_OPTION, VARARGS.option("files...")};
+  static final Option<?> CREATE_FLAG = FLAG.option("-c", "--create").withHelp("Create an archive");
+  static final Option<?> FILE_OPTION = SINGLE.option("-f", "--file").withHelp("The archive file");
+  static final Option<?>[] OPTIONS = {CREATE_FLAG, FILE_OPTION, VARARGS.option("files...")};
 
   private static Map<String, Value> splitInput(String line) {
     return Splitter.of(OPTIONS).split(line.split("\\s+"));

--- a/test/test/jdk/JarValueTests.java
+++ b/test/test/jdk/JarValueTests.java
@@ -1,11 +1,9 @@
 package test.jdk;
 
-import static main.Option.Type.FLAG;
-import static main.Option.Type.SINGLE;
-import static main.Option.Type.VARARGS;
 import static test.api.Assertions.assertEquals;
 import static test.api.Assertions.assertEqualsOptional;
 
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 import main.Option;
@@ -20,12 +18,13 @@ public class JarValueTests {
     JTest.runTests(new JarValueTests(), args);
   }
 
-  static final Option<?> CREATE_FLAG = FLAG.option("-c", "--create").withHelp("Create an archive");
-  static final Option<?> FILE_OPTION = SINGLE.option("-f", "--file").withHelp("The archive file");
-  static final Option<?>[] OPTIONS = {CREATE_FLAG, FILE_OPTION, VARARGS.option("files...")};
+  static final Option<?> CREATE_FLAG =
+      Option.ofFlag("-c", "--create").withHelp("Create an archive");
+  static final Option<?> FILE_OPTION = Option.ofSingle("-f", "--file").withHelp("The archive file");
+  static final Option<Path> FILES_OPTION = Option.ofVarargs(Path.class, Path::of, "files...");
 
-  private static Map<String, Value> splitInput(String line) {
-    return Splitter.of(OPTIONS).split(line.split("\\s+"));
+  private static Map<String, Value<?>> splitInput(String line) {
+    return Splitter.of(CREATE_FLAG, FILE_OPTION, FILES_OPTION).split(line.split("\\s+"));
   }
 
   @Test
@@ -34,6 +33,7 @@ public class JarValueTests {
     assertEquals(Set.of("-c", "--create", "-f", "--file", "files..."), values.keySet());
     assertEqualsOptional("classes.jar", ((Value.SingleValue) values.get("-f")).value());
     assertEquals(
-        new Value.VarargsValue(OPTIONS[2], "Foo.class", "Bar.class"), values.get("files..."));
+        new Value.VarargsValue(FILES_OPTION, Path.of("Foo.class"), Path.of("Bar.class")),
+        values.get("files..."));
   }
 }


### PR DESCRIPTION
Adds basic type conversion to options. 
This means options may be based upon a simple value type  other than `String`.
The simple type is kept in `valueType`. A `Function` is provided to convert between `String` and the target type.
The conversion only applies to `String` based option types (single, repeatable, required, varargs).

For Records the lookup is also used to try to find a static factory function for the target type.
This should support most JDK types already and will work for user types as long as they have one of the supported signatures and are accessible for the lookup used. 