### PR TITLE
Use adt for Option

### DIFF
--- a/main/main/Manual.java
+++ b/main/main/Manual.java
@@ -15,7 +15,7 @@ public class Manual {
     requireNonNull(schema, "schema is null");
     if (indent < 0) throw new IllegalArgumentException("invalid indent " + indent);
     var joiner = new StringJoiner("\n");
-    for (var option : schema.options.stream().sorted(Comparator.comparing(Option::name)).toList()) {
+    for (var option : schema.options.stream().sorted(Comparator.comparing(Manual::optionName)).toList()) {
       var text = option.help();
       if (text.isEmpty()) continue;
       var suffix =
@@ -32,5 +32,9 @@ public class Manual {
       joiner.add(text.indent(indent).stripTrailing());
     }
     return joiner.toString();
+  }
+
+  private static String optionName(Option<?> option) {
+    return option.names().iterator().next();
   }
 }

--- a/main/main/NameSet.java
+++ b/main/main/NameSet.java
@@ -1,0 +1,90 @@
+package main;
+
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+
+import static java.util.Objects.requireNonNull;
+
+final class NameSet extends AbstractSet<String> {
+  private final LinkedHashSet<String> set;
+
+  private NameSet(LinkedHashSet<String> set) {
+    this.set = set;
+  }
+
+  @Override
+  public int size() {
+    return set.size();
+  }
+
+  @Override
+  public Iterator<String> iterator() {
+    var iterator = set.iterator();
+    return new Iterator<>() {
+      @Override
+      public boolean hasNext() {
+        return iterator.hasNext();
+      }
+
+      @Override
+      public String next() {
+        return iterator.next();
+      }
+    };
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    requireNonNull(o, "o is null");
+    return set.contains(o);
+  }
+
+  @Override
+  public Spliterator<String> spliterator() {
+    return Spliterators.spliterator(this, Spliterator.DISTINCT | Spliterator.ORDERED | Spliterator.NONNULL);
+  }
+
+  public static Set<String> of(String... names) {
+    requireNonNull(names, "names is null");
+    if (names.length == 0) {
+      throw new IllegalArgumentException("names is empty");
+    }
+    var set = new LinkedHashSet<String>();
+    for(var name: names) {
+      requireNonNull(name, "name is null");
+      if (name.isEmpty()) {
+        throw new IllegalArgumentException("one name is empty");
+      }
+      if (!set.add(name)) {
+        throw new IllegalArgumentException("duplicate names " + name);
+      }
+    }
+    return new NameSet(set);
+  }
+
+  public static Set<String> copyOf(Collection<? extends String> names) {
+    requireNonNull(names, "names is null");
+    if (names instanceof NameSet nameSet) {
+      return nameSet;
+    }
+    if (names.isEmpty()) {
+      throw new IllegalArgumentException("names is empty");
+    }
+    var set = new LinkedHashSet<String>();
+    for(var name: names) {
+      requireNonNull(name, "name is null");
+      if (name.isEmpty()) {
+        throw new IllegalArgumentException("one name is empty");
+      }
+      if (!set.add(name)) {
+        throw new IllegalArgumentException("duplicate names " + name);
+      }
+    }
+    return new NameSet(set);
+  }
+}

--- a/main/main/NameSet.java
+++ b/main/main/NameSet.java
@@ -1,6 +1,7 @@
 package main;
 
 import java.util.AbstractSet;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -51,20 +52,7 @@ final class NameSet extends AbstractSet<String> {
 
   public static Set<String> of(String... names) {
     requireNonNull(names, "names is null");
-    if (names.length == 0) {
-      throw new IllegalArgumentException("names is empty");
-    }
-    var set = new LinkedHashSet<String>();
-    for(var name: names) {
-      requireNonNull(name, "name is null");
-      if (name.isEmpty()) {
-        throw new IllegalArgumentException("one name is empty");
-      }
-      if (!set.add(name)) {
-        throw new IllegalArgumentException("duplicate names " + name);
-      }
-    }
-    return new NameSet(set);
+    return copyOf(Arrays.asList(names));
   }
 
   public static Set<String> copyOf(Collection<? extends String> names) {

--- a/main/main/Option.java
+++ b/main/main/Option.java
@@ -2,12 +2,13 @@ package main;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
 /**
@@ -42,11 +43,11 @@ import java.util.stream.Stream;
  *
  * @param <T> type of the argument described by this Option.
  */
-public class Option<T> {
+public sealed interface Option<T> {
   /**
    * Type of {@link Option}.
    */
-  public enum Type {
+  enum Type {
     BRANCH(null),
     /** An optional flag, like {@code --verbose}. */
     FLAG(false),
@@ -66,34 +67,273 @@ public class Option<T> {
     }
   }
 
-  private final Type type;
-  private final LinkedHashSet<String> names;
-  private final Function<Object, T> toValue;
-  private final String help;
-  private final Schema<?> nestedSchema;
+  record Branch<T>(List<String> names, UnaryOperator<T> toValue, String help, Schema<T> nestedSchema) implements Option<T> {
+    public Branch {
+      requireNonNull(names, "names is null");
+      requireNonNull(toValue, "toValue is null");
+      requireNonNull(help, "help null");
+      requireNonNull(nestedSchema, "nestedSchema null");
+      names = checkDuplicates(List.copyOf(names));
+    }
 
-  private Option(Type type, LinkedHashSet<String> names,  Function<Object, T> toValue, String help, Schema<?> nestedSchema) {
-    requireNonNull(type, "type is null");
-    requireNonNull(names, "names is null");
-    requireNonNull(toValue, "toValue is null");
-    requireNonNull(help, "help is null");
-    if (names.isEmpty()) throw new IllegalArgumentException("no name defined");
-    this.type = type;
-    this.names = names;
-    this.toValue = toValue;
-    this.help = help;
-    this.nestedSchema = nestedSchema;
+    @Override
+    public String toString() {
+      return "BRANCH" + names.toString();
+    }
+
+    @Override
+    public Branch<T> help(String helpText) {
+      requireNonNull(names, "helpText is null");
+      if (!help.isEmpty()) {
+        throw new IllegalStateException("option already has an help text");
+      }
+      return new Branch<>(names, toValue, helpText, nestedSchema);
+    }
+
+    @Override
+    public Branch<T> nestedSchema(Schema<?> nestedSchema) {
+      requireNonNull(nestedSchema, "nestedSchema is null");
+      throw new IllegalStateException("a nested schema is already set");
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <U> Option<U> map(Function<? super T, ? extends U> conversion) {
+      requireNonNull(conversion, "conversion is null");
+      return new Branch<>(names, v -> conversion.apply(toValue.apply((T) v)), help, (Schema<U>) nestedSchema);
+    }
+
+    public Branch<T> convert(UnaryOperator<T> mapper) {
+      requireNonNull(mapper, "mapper is null");
+      return new Branch<>(names, v -> mapper.apply(toValue.apply(v)), help, nestedSchema);
+    }
   }
 
-  Option(Type type, String[] names,  Function<Object, T> toValue, String help, Schema<?> nestedSchema) {
-    this(type, checkDuplicates(names), toValue, help, nestedSchema);
+  record Flag(List<String> names, UnaryOperator<Boolean> toValue, String help, Schema<?> nestedSchema) implements Option<Boolean> {
+    public Flag {
+      requireNonNull(names, "names is null");
+      requireNonNull(toValue, "toValue is null");
+      requireNonNull(help, "help null");
+      names = checkDuplicates(List.copyOf(names));
+    }
+
+    @Override
+    public String toString() {
+      return "FLAG" + names.toString();
+    }
+
+    @Override
+    public Flag help(String helpText) {
+      requireNonNull(names, "helpText is null");
+      if (!help.isEmpty()) {
+        throw new IllegalStateException("option already has an help text");
+      }
+      return new Flag(names, toValue, helpText, nestedSchema);
+    }
+
+    @Override
+    public Flag nestedSchema(Schema<?> nestedSchema) {
+      requireNonNull(nestedSchema, "nestedSchema is null");
+      if (this.nestedSchema != null) {
+        throw new IllegalStateException("a nested schema is already set");
+      }
+      return new Flag(names, toValue, help, nestedSchema);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <U> Option<U> map(Function<? super Boolean, ? extends U> conversion) {
+      requireNonNull(conversion, "conversion is null");
+      return (Option<U>) convert(v -> (Boolean) conversion.apply(v));
+    }
+
+    public Flag convert(UnaryOperator<Boolean> mapper) {
+      requireNonNull(mapper, "mapper is null");
+      return new Flag(names, v -> mapper.apply(toValue.apply(v)), help, nestedSchema);
+    }
   }
 
-  private static LinkedHashSet<String> checkDuplicates(String... names) {
-    requireNonNull(names, "names is null");
+  record Single<T>(List<String> names, Function<? super Optional<String>, ? extends Optional<T>> toValue, String help, Schema<?> nestedSchema) implements Option<Optional<T>> {
+    public Single {
+      requireNonNull(names, "names is null");
+      requireNonNull(toValue, "toValue is null");
+      requireNonNull(help, "help null");
+      names = checkDuplicates(List.copyOf(names));
+    }
+
+    @Override
+    public String toString() {
+      return "SINGLE" + names.toString();
+    }
+
+    @Override
+    public Single<T> help(String helpText) {
+      requireNonNull(names, "helpText is null");
+      if (!help.isEmpty()) {
+        throw new IllegalStateException("option already has an help text");
+      }
+      return new Single<>(names, toValue, helpText, nestedSchema);
+    }
+
+    @Override
+    public Single<T> nestedSchema(Schema<?> nestedSchema) {
+      requireNonNull(nestedSchema, "nestedSchema is null");
+      if (this.nestedSchema != null) {
+        throw new IllegalStateException("a nested schema is already set");
+      }
+      return new Single<>(names, toValue, help, nestedSchema);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <U> Option<U> map(Function<? super Optional<T>, ? extends U> conversion) {
+      requireNonNull(conversion, "conversion is null");
+      return (Option<U>) new Single<>(names, toValue.andThen(v -> (Optional<?>) conversion.apply(v)), help, nestedSchema);
+    }
+
+    public <U> Single<U> convert(Function<? super T, ? extends U> mapper) {
+      requireNonNull(mapper, "mapper is null");
+      return new Single<>(names, toValue.andThen(v -> v.map(mapper)), help, nestedSchema);
+    }
+  }
+
+  record Repeatable<T>(List<String> names, Function<? super List<String>, ? extends List<T>> toValue, String help, Schema<?> nestedSchema) implements Option<List<T>> {
+    public Repeatable {
+      requireNonNull(names, "names is null");
+      requireNonNull(toValue, "toValue is null");
+      requireNonNull(help, "help null");
+      names = checkDuplicates(List.copyOf(names));
+    }
+
+    @Override
+    public String toString() {
+      return "REPEATABLE" + names.toString();
+    }
+
+    @Override
+    public Repeatable<T> help(String helpText) {
+      requireNonNull(names, "helpText is null");
+      if (!help.isEmpty()) {
+        throw new IllegalStateException("option already has an help text");
+      }
+      return new Repeatable<>(names, toValue, helpText, nestedSchema);
+    }
+
+    @Override
+    public Repeatable<T> nestedSchema(Schema<?> nestedSchema) {
+      requireNonNull(nestedSchema, "nestedSchema is null");
+      if (this.nestedSchema != null) {
+        throw new IllegalStateException("a nested schema is already set");
+      }
+      return new Repeatable<>(names, toValue, help, nestedSchema);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <U> Option<U> map(Function<? super List<T>, ? extends U> conversion) {
+      requireNonNull(conversion, "conversion is null");
+      return (Option<U>) new Repeatable<>(names, toValue.andThen(v -> (List<?>) conversion.apply(v)), help, nestedSchema);
+    }
+
+    public <U> Repeatable<U> convert(Function<? super T, ? extends U> mapper) {
+      requireNonNull(mapper, "mapper is null");
+      return new Repeatable<>(names, toValue.andThen(list -> list.stream().<U>map(mapper).toList()), help, nestedSchema);
+    }
+  }
+
+  record Required<T>(List<String> names, Function<? super String, ? extends T> toValue, String help, Schema<?> nestedSchema) implements Option<T> {
+    public Required {
+      requireNonNull(names, "names is null");
+      requireNonNull(toValue, "toValue is null");
+      requireNonNull(help, "help null");
+      names = checkDuplicates(List.copyOf(names));
+    }
+
+    @Override
+    public String toString() {
+      return "REQUIRED" + names.toString();
+    }
+
+    @Override
+    public Required<T> help(String helpText) {
+      requireNonNull(names, "helpText is null");
+      if (!help.isEmpty()) {
+        throw new IllegalStateException("option already has an help text");
+      }
+      return new Required<>(names, toValue, helpText, nestedSchema);
+    }
+
+    @Override
+    public Required<T> nestedSchema(Schema<?> nestedSchema) {
+      requireNonNull(nestedSchema, "nestedSchema is null");
+      if (this.nestedSchema != null) {
+        throw new IllegalStateException("a nested schema is already set");
+      }
+      return new Required<>(names, toValue, help, nestedSchema);
+    }
+
+    @Override
+    public <U> Option<U> map(Function<? super T, ? extends U> conversion) {
+      requireNonNull(conversion, "conversion is null");
+      return convert(conversion);
+    }
+
+    public <U> Required<U> convert(Function<? super T, ? extends U> mapper) {
+      requireNonNull(mapper, "mapper is null");
+      return new Required<>(names, toValue.andThen(mapper), help, nestedSchema);
+    }
+  }
+
+  record Varargs<T>(List<String> names, Function<? super String[], ? extends T[]> toValue, String help, Schema<?> nestedSchema) implements Option<T[]> {
+    public Varargs {
+      requireNonNull(names, "names is null");
+      requireNonNull(toValue, "toValue is null");
+      requireNonNull(help, "help null");
+      names = checkDuplicates(List.copyOf(names));
+    }
+
+    @Override
+    public String toString() {
+      return "VARARGS" + names.toString();
+    }
+
+    @Override
+    public Varargs<T> help(String helpText) {
+      requireNonNull(names, "helpText is null");
+      if (!help.isEmpty()) {
+        throw new IllegalStateException("option already has an help text");
+      }
+      return new Varargs<>(names, toValue, helpText, nestedSchema);
+    }
+
+    @Override
+    public Varargs<T> nestedSchema(Schema<?> nestedSchema) {
+      requireNonNull(nestedSchema, "nestedSchema is null");
+      if (this.nestedSchema != null) {
+        throw new IllegalStateException("a nested schema is already set");
+      }
+      return new Varargs<>(names, toValue, help, nestedSchema);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <U> Option<U> map(Function<? super T[], ? extends U> conversion) {
+      requireNonNull(conversion, "conversion is null");
+      return (Option<U>) new Varargs<>(names, toValue.andThen(v -> (Object[]) conversion.apply(v)), help, nestedSchema);
+    }
+
+    public <U> Varargs<U> convert(Function<? super T, ? extends U> mapper, IntFunction<U[]> generator) {
+      requireNonNull(mapper, "mapper is null");
+      return new Varargs<>(names, toValue.andThen(v -> Arrays.stream(v).map(mapper).toArray(generator)), help, nestedSchema);
+    }
+  }
+
+  private static List<String> checkDuplicates(List<String> names) {
+    if (names.isEmpty()) {
+      throw new IllegalArgumentException("no name defined");
+    }
     var set = new LinkedHashSet<String>();
     for(var name: names) {
-      requireNonNull(name, "one name is null");
       if (name.isEmpty()) {
         throw new IllegalArgumentException("one name is empty");
       }
@@ -101,39 +341,62 @@ public class Option<T> {
         throw new IllegalArgumentException("duplicate names " + name);
       }
     }
-    return set;
+    return names;
   }
 
   /**
    * Returns the type of the option.
    * @return the type of the option.
    */
-  public Type type() {
-    return type;
+  default Type type() {
+    if (this instanceof Branch<?>) {
+      return Type.BRANCH;
+    }
+    if (this instanceof Flag) {
+      return Type.FLAG;
+    }
+    if (this instanceof Single<?>) {
+      return Type.SINGLE;
+    }
+    if (this instanceof Repeatable<?>) {
+      return Type.REPEATABLE;
+    }
+    if (this instanceof Required<?>) {
+      return Type.REQUIRED;
+    }
+    if (this instanceof Option.Varargs<?>) {
+      return Type.VARARGS;
+    }
+    throw new AssertionError();
   }
 
   /**
    * Returns the names of the options.
    * @return the named of the options.
    */
-  public Set<String> names() {
-    return Collections.unmodifiableSet(names);
-  }
+  List<String> names();
 
   /**
    * Returns the text of the help message.
    * @return the text of the help message or an empty string if no text is set.
    */
-  public String help() {
-    return help;
-  }
+  String help();
 
   /**
    * Returns the nested schema if it exists.
    * @return the nested schema or {@code null} otherwise.
    */
-  public Schema<?> nestedSchema() {
-    return nestedSchema;
+  Schema<?> nestedSchema();
+
+  /**
+   * Creates an option of type {@link Type#BRANCH} with names.
+   *
+   * @param names the names of the options.
+   * @return a new {@link Type#BRANCH} option.
+   * @throws IllegalArgumentException is there are duplicated names.
+   */
+  static <T extends Record> Branch<T> branch(String... names) {
+    return new Branch<>(Arrays.asList(names), value -> value, "", null);
   }
 
   /**
@@ -143,8 +406,8 @@ public class Option<T> {
    * @return a new {@link Type#FLAG} option.
    * @throws IllegalArgumentException is there are duplicated names.
    */
-  public static Option<Boolean> flag(String... names) {
-    return new Option<>(Type.FLAG, names, object -> (Boolean) object, "", null);
+  static Flag flag(String... names) {
+    return new Flag(Arrays.asList(names), value -> value, "", null);
   }
 
   /**
@@ -154,20 +417,8 @@ public class Option<T> {
    * @return a new {@link Type#SINGLE} option.
    * @throws IllegalArgumentException is there are duplicated names.
    */
-  @SuppressWarnings("unchecked")
-  public static Option<Optional<String>> single(String... names) {
-    return new Option<>(Type.SINGLE, names, object -> (Optional<String>) object, "", null);
-  }
-
-  /**
-   * Creates an option of type {@link Type#REQUIRED} with names.
-   *
-   * @param names the names of the options.
-   * @return a new {@link Type#REQUIRED} option.
-   * @throws IllegalArgumentException is there are duplicated names.
-   */
-  public static Option<String> required(String... names) {
-    return new Option<>(Type.REQUIRED, names, object -> (String) object, "", null);
+  static Single<String> single(String... names) {
+    return new Single<>(Arrays.asList(names), value -> value, "", null);
   }
 
   /**
@@ -177,9 +428,19 @@ public class Option<T> {
    * @return a new {@link Type#REPEATABLE} option.
    * @throws IllegalArgumentException is there are duplicated names.
    */
-  @SuppressWarnings("unchecked")
-  public static Option<List<String>> repeatable(String... names) {
-    return new Option<>(Type.REPEATABLE, names, object -> (List<String>) object, "", null);
+  static Repeatable<String> repeatable(String... names) {
+    return new Repeatable<>(Arrays.asList(names), value -> value, "", null);
+  }
+
+  /**
+   * Creates an option of type {@link Type#REQUIRED} with names.
+   *
+   * @param names the names of the options.
+   * @return a new {@link Type#REQUIRED} option.
+   * @throws IllegalArgumentException is there are duplicated names.
+   */
+  static Required<String> required(String... names) {
+    return new Required<>(Arrays.asList(names), value -> value, "", null);
   }
 
   /**
@@ -189,8 +450,8 @@ public class Option<T> {
    * @return a new {@link Type#VARARGS} option.
    * @throws IllegalArgumentException is there are duplicated names.
    */
-  public static Option<String[]> varargs(String... names) {
-    return new Option<>(Type.VARARGS, names, object -> (String[]) object, "", null);
+  static Varargs<String> varargs(String... names) {
+    return new Varargs<>(Arrays.asList(names), value -> value, "", null);
   }
 
   /**
@@ -198,9 +459,7 @@ public class Option<T> {
    * @return a string representation of the option using its {@link #type()} and its {@link #names()}.
    */
   @Override
-  public String toString() {
-    return type + names.toString();
-  }
+  String toString();
 
   /**
    * Returns a new option configured with the conversion function.
@@ -218,10 +477,8 @@ public class Option<T> {
    * @return a new option configured with the conversion function.
    * @param <U> type of the return value of the conversion function
    */
-  public <U> Option<U> map(Function<? super T, ? extends U> conversion) {
-    requireNonNull(conversion, "conversion is null");
-    return new Option<>(type, names, toValue.andThen(conversion), help, nestedSchema);
-  }
+  <U> Option<U> map(Function<? super T, ? extends U> conversion);
+
 
   /**
    * Returns a new option with the help text.
@@ -230,13 +487,7 @@ public class Option<T> {
    * @return a new option with the help text.
    * @throws IllegalStateException if the option already has a help text set.
    */
-  public Option<T> help(String helpText) {
-    requireNonNull(names, "helpText is null");
-    if (!help.isEmpty()) {
-      throw new IllegalStateException("option already has an help text");
-    }
-    return new Option<>(type, names, toValue, helpText, nestedSchema);
-  }
+  Option<T> help(String helpText);
 
   /**
    * Returns a new option with the nested schema.
@@ -245,13 +496,7 @@ public class Option<T> {
    * @return a new option with the nested schema.
    * @throws IllegalStateException if the option already has a nested schema set.
    */
-  public Option<?> nestedSchema(Schema<?> nestedSchema) {
-    requireNonNull(nestedSchema, "nestedSchema is null");
-    if (this.nestedSchema != null) {
-      throw new IllegalStateException("a nested schema is already set");
-    }
-    return new Option<>(type, names, toValue, help, nestedSchema);
-  }
+  Option<?> nestedSchema(Schema<?> nestedSchema);
 
   /**
    * Returns the value of the argument associated with the current option.
@@ -261,37 +506,74 @@ public class Option<T> {
    * @throws IllegalStateException if there is no argument value associated with the current option
    * in the {@link ArgumentMap}.
    */
-  public T argument(ArgumentMap argumentMap) {
+  default T argument(ArgumentMap argumentMap) {
     requireNonNull(argumentMap, "dataMap is null");
     return argumentMap.argument(this);
   }
 
+  // FIXME the following methods are too visible
   @SuppressWarnings("unchecked")
-  T defaultValue() {
-    return (T) type.defaultValue;
+  default T defaultValue() {
+    return (T) type().defaultValue;
   }
 
-  T apply(Object arg) {
-    return toValue.apply(arg);
+  @SuppressWarnings("unchecked")
+  default T apply(Object arg) {
+    if (this instanceof Branch<T> branch) {
+      return (T) branch.toValue.apply((T) arg);
+    }
+    if (this instanceof Flag flag) {
+      return (T) flag.toValue.apply((Boolean) arg);
+    }
+    if (this instanceof Single<?> single) {
+      return (T) single.toValue.apply((Optional<String>) arg);
+    }
+    if (this instanceof Repeatable<?> repeatable) {
+      return (T) repeatable.toValue.apply((List<String>) arg);
+    }
+    if (this instanceof Required<T> required) {
+      return required.toValue.apply((String) arg);
+    }
+    if (this instanceof Option.Varargs<?> varargs) {
+      return (T) varargs.toValue.apply((String[]) arg);
+    }
+    throw new AssertionError();
   }
 
-  String name() {
-    return names.iterator().next();
+  default String name() {
+    return names().iterator().next();
   }
 
-  boolean isVarargs() {
-    return type == Type.VARARGS;
+  default boolean isVarargs() {
+    return type() == Type.VARARGS;
   }
 
-  boolean isRequired() {
-    return type == Type.REQUIRED;
+  default boolean isRequired() {
+    return type() == Type.REQUIRED;
   }
 
-  boolean isFlag() {
-    return type == Type.FLAG;
+  default boolean isFlag() {
+    return type() == Type.FLAG;
   }
 
-  boolean isPositional() {
-    return type == Type.VARARGS || type == Type.REQUIRED;
+  default boolean isPositional() {
+    return type() == Type.VARARGS || type() == Type.REQUIRED;
+  }
+
+  static Option<?> newOption(Type type, String[] names, Function<Object, ?> converter, String help, Schema<?> schema) {
+    var nameList = Arrays.asList(names);
+    return switch (type) {
+      case BRANCH -> newBranch(nameList, converter, help, schema);
+      case FLAG -> new Flag(nameList, v -> (Boolean) converter.apply(v), help, schema);
+      case SINGLE -> new Single<>(nameList, v -> (Optional<?>) converter.apply(v), help, schema);
+      case REPEATABLE -> new Repeatable<>(nameList, v -> (List<?>) converter.apply(v), help, schema);
+      case REQUIRED -> new Required<>(nameList, converter, help, schema);
+      case VARARGS -> new Varargs<>(nameList, v -> (Object[]) converter.apply(v), help, schema);
+    };
+  }
+
+  @SuppressWarnings("unchecked")  // need to capture the Schema type
+  private static <T> Branch<T> newBranch(List<String> nameList, Function<Object, ?> converter, String help, Schema<T> schema) {
+    return new Branch<>(nameList, v -> (T) converter.apply(v), help, schema);
   }
 }

--- a/main/main/Option.java
+++ b/main/main/Option.java
@@ -96,13 +96,6 @@ public sealed interface Option<T> {
       throw new IllegalStateException("a nested schema is already set");
     }
 
-    /*@Override
-    @SuppressWarnings("unchecked")
-    public <U> Option<U> map(Function<? super T, ? extends U> conversion) {
-      requireNonNull(conversion, "conversion is null");
-      return new Branch<>(names, v -> conversion.apply(toValue.apply((T) v)), help, (Schema<U>) nestedSchema);
-    }*/
-
     public Branch<T> convert(UnaryOperator<T> mapper) {
       requireNonNull(mapper, "mapper is null");
       return new Branch<>(names, v -> mapper.apply(toValue.apply(v)), help, nestedSchema);
@@ -144,13 +137,6 @@ public sealed interface Option<T> {
       }
       return new Flag(names, toValue, help, nestedSchema);
     }
-
-    /*@Override
-    @SuppressWarnings("unchecked")
-    public <U> Option<U> map(Function<? super Boolean, ? extends U> conversion) {
-      requireNonNull(conversion, "conversion is null");
-      return (Option<U>) convert(v -> (Boolean) conversion.apply(v));
-    }*/
 
     public Flag convert(UnaryOperator<Boolean> mapper) {
       requireNonNull(mapper, "mapper is null");
@@ -195,13 +181,6 @@ public sealed interface Option<T> {
       return new Single<>(names, toValue, help, nestedSchema);
     }
 
-    /*@Override
-    @SuppressWarnings("unchecked")
-    public <U> Option<U> map(Function<? super Optional<T>, ? extends U> conversion) {
-      requireNonNull(conversion, "conversion is null");
-      return (Option<U>) new Single<>(names, toValue.andThen(v -> (Optional<?>) conversion.apply(v)), help, nestedSchema);
-    }*/
-
     public <U> Single<U> convert(Function<? super T, ? extends U> mapper) {
       requireNonNull(mapper, "mapper is null");
       return new Single<>(names, toValue.andThen(v -> v.map(mapper)), help, nestedSchema);
@@ -244,13 +223,6 @@ public sealed interface Option<T> {
       }
       return new Repeatable<>(names, toValue, help, nestedSchema);
     }
-
-    /*@Override
-    @SuppressWarnings("unchecked")
-    public <U> Option<U> map(Function<? super List<T>, ? extends U> conversion) {
-      requireNonNull(conversion, "conversion is null");
-      return (Option<U>) new Repeatable<>(names, toValue.andThen(v -> (List<?>) conversion.apply(v)), help, nestedSchema);
-    }*/
 
     public <U> Repeatable<U> convert(Function<? super T, ? extends U> mapper) {
       requireNonNull(mapper, "mapper is null");
@@ -295,12 +267,6 @@ public sealed interface Option<T> {
       return new Required<>(names, toValue, help, nestedSchema);
     }
 
-    /*@Override
-    public <U> Option<U> map(Function<? super T, ? extends U> conversion) {
-      requireNonNull(conversion, "conversion is null");
-      return convert(conversion);
-    }*/
-
     public <U> Required<U> convert(Function<? super T, ? extends U> mapper) {
       requireNonNull(mapper, "mapper is null");
       return new Required<>(names, toValue.andThen(mapper), help, nestedSchema);
@@ -342,13 +308,6 @@ public sealed interface Option<T> {
       }
       return new Varargs<>(names, toValue, help, nestedSchema);
     }
-
-    /*@Override
-    @SuppressWarnings("unchecked")
-    public <U> Option<U> map(Function<? super T[], ? extends U> conversion) {
-      requireNonNull(conversion, "conversion is null");
-      return (Option<U>) new Varargs<>(names, toValue.andThen(v -> (Object[]) conversion.apply(v)), help, nestedSchema);
-    }*/
 
     public <U> Varargs<U> convert(Function<? super T, ? extends U> mapper, IntFunction<U[]> generator) {
       requireNonNull(mapper, "mapper is null");
@@ -479,24 +438,6 @@ public sealed interface Option<T> {
    */
   @Override
   String toString();
-
-  /**
-   * Returns a new option configured with the conversion function.
-   *
-   * <p>The return type of the conversion function must be an equivalent type of the type of the option.
-   * If the option is a {@link Type#FLAG}, the return type must be a {@code Boolean},
-   * if the option is a {@link Type#SINGLE}, the return type must be any {@code Optional}s,
-   * if the option is a {@link Type#REPEATABLE}, the return type must be any {@code List}s,
-   * if the option is a {@link Type#REQUIRED}, the return type must be any {@code Object}s,
-   * if the option is a {@link Type#VARARGS}, the return type must be any arrays of objects ({@code Object[]}).
-   *
-   * <p>This restriction is not enforced but may result in {@link ClassCastException} later if not followed.
-   *
-   * @param conversion a conversion function
-   * @return a new option configured with the conversion function.
-   * @param <U> type of the return value of the conversion function
-   */
-  //<U> Option<U> map(Function<? super T, ? extends U> conversion);
 
   /**
    * Returns a new option configured with a default value.

--- a/main/main/Option.java
+++ b/main/main/Option.java
@@ -60,7 +60,7 @@ public sealed interface Option<T> {
     /** A collection of all unhandled arguments. */
     VARARGS(new String[0]);
 
-    private final Object defaultValue;
+    final Object defaultValue;
 
     Type(Object defaultValue) {
       this.defaultValue = defaultValue;
@@ -550,71 +550,5 @@ public sealed interface Option<T> {
   default T argument(ArgumentMap argumentMap) {
     requireNonNull(argumentMap, "dataMap is null");
     return argumentMap.argument(this);
-  }
-
-  // FIXME the following methods are too visible
-  @SuppressWarnings("unchecked")
-  default T defaultValue() {
-    return (T) type().defaultValue;
-  }
-
-  @SuppressWarnings("unchecked")
-  default T apply(Object arg) {
-    if (this instanceof Branch<T> branch) {
-      return (T) branch.toValue.apply((T) arg);
-    }
-    if (this instanceof Flag flag) {
-      return (T) flag.toValue.apply((Boolean) arg);
-    }
-    if (this instanceof Single<?> single) {
-      return (T) single.toValue.apply((Optional<String>) arg);
-    }
-    if (this instanceof Repeatable<?> repeatable) {
-      return (T) repeatable.toValue.apply((List<String>) arg);
-    }
-    if (this instanceof Required<T> required) {
-      return required.toValue.apply((String) arg);
-    }
-    if (this instanceof Option.Varargs<?> varargs) {
-      return (T) varargs.toValue.apply((String[]) arg);
-    }
-    throw new AssertionError();
-  }
-
-  default String name() {
-    return names().iterator().next();
-  }
-
-  default boolean isVarargs() {
-    return type() == Type.VARARGS;
-  }
-
-  default boolean isRequired() {
-    return type() == Type.REQUIRED;
-  }
-
-  default boolean isFlag() {
-    return type() == Type.FLAG;
-  }
-
-  default boolean isPositional() {
-    return type() == Type.VARARGS || type() == Type.REQUIRED;
-  }
-
-  static Option<?> newOption(Type type, String[] names, Function<Object, ?> converter, String help, Schema<?> schema) {
-    var nameList = Arrays.asList(names);
-    return switch (type) {
-      case BRANCH -> newBranch(nameList, converter, help, schema);
-      case FLAG -> new Flag(nameList, v -> (Boolean) converter.apply(v), help, schema);
-      case SINGLE -> new Single<>(nameList, v -> (Optional<?>) converter.apply(v), help, schema);
-      case REPEATABLE -> new Repeatable<>(nameList, v -> (List<?>) converter.apply(v), help, schema);
-      case REQUIRED -> new Required<>(nameList, converter, help, schema);
-      case VARARGS -> new Varargs<>(nameList, v -> (Object[]) converter.apply(v), help, schema);
-    };
-  }
-
-  @SuppressWarnings("unchecked")  // need to capture the Schema type
-  private static <T> Branch<T> newBranch(List<String> nameList, Function<Object, ?> converter, String help, Schema<T> schema) {
-    return new Branch<>(nameList, v -> (T) converter.apply(v), help, schema);
   }
 }

--- a/main/main/RecordSchemaSupport.java
+++ b/main/main/RecordSchemaSupport.java
@@ -47,7 +47,7 @@ class RecordSchemaSupport {
     var nestedSchema = toNestedSchema(component);
     var converter = resolveConverter(lookup, component, resolver);
     var optionSchema = nestedSchema == null ? null: toSchema(lookup, nestedSchema, resolver);
-    return new Option<>(type, names, converter, help, optionSchema);
+    return Option.newOption(type, names, converter, help, optionSchema);
   }
 
   private static Function<Object, ?> resolveConverter(Lookup lookup, RecordComponent component, ConverterResolver resolver) {

--- a/main/main/RecordSchemaSupport.java
+++ b/main/main/RecordSchemaSupport.java
@@ -14,9 +14,9 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.RecordComponent;
 import java.lang.reflect.UndeclaredThrowableException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -81,21 +81,21 @@ class RecordSchemaSupport {
         : null;
   }
 
-  static Option<?> newOption(Type type, String[] names, Function<Object, ?> converter, String help, Schema<?> schema) {
-    var nameList = Arrays.asList(names);
+  private static Option<?> newOption(Type type, String[] names, Function<Object, ?> converter, String help, Schema<?> schema) {
+    var nameSet = NameSet.of(names);
     return switch (type) {
-      case BRANCH -> newBranch(nameList, converter, help, schema);
-      case FLAG -> new Flag(nameList, v -> (Boolean) converter.apply(v), help, schema);
-      case SINGLE -> new Single<>(nameList, v -> (Optional<?>) converter.apply(v), help, schema);
-      case REPEATABLE -> new Repeatable<>(nameList, v -> (List<?>) converter.apply(v), help, schema);
-      case REQUIRED -> new Required<>(nameList, converter, help, schema);
-      case VARARGS -> new Varargs<>(nameList, v -> (Object[]) converter.apply(v), help, schema);
+      case BRANCH -> newBranch(nameSet, converter, help, schema);
+      case FLAG -> new Flag(nameSet, v -> (Boolean) converter.apply(v), help, schema);
+      case SINGLE -> new Single<>(nameSet, v -> (Optional<?>) converter.apply(v), help, schema);
+      case REPEATABLE -> new Repeatable<>(nameSet, v -> (List<?>) converter.apply(v), help, schema);
+      case REQUIRED -> new Required<>(nameSet, converter, help, schema);
+      case VARARGS -> new Varargs<>(nameSet, v -> (Object[]) converter.apply(v), help, schema);
     };
   }
 
   @SuppressWarnings("unchecked")  // need to capture the Schema type
-  private static <T> Branch<T> newBranch(List<String> nameList, Function<Object, ?> converter, String help, Schema<T> schema) {
-    return new Branch<>(nameList, v -> (T) converter.apply(v), help, schema);
+  private static <T> Branch<T> newBranch(Set<String> nameSet, Function<Object, ?> converter, String help, Schema<T> schema) {
+    return new Branch<>(nameSet, v -> (T) converter.apply(v), help, schema);
   }
 
   private static MethodHandle constructor(Lookup lookup, Class<?> schema) {

--- a/test/test/ConverterTests.java
+++ b/test/test/ConverterTests.java
@@ -9,7 +9,6 @@ import test.api.JTest;
 import test.api.JTest.Test;
 
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,9 +26,9 @@ class ConverterTests {
   @Test
   void simple() {
     var version = Option.single("-v", "--version")
-        .map(opt -> opt.map(Integer::parseInt));
+        .convert(Integer::parseInt);
     var rest = Option.varargs("rest")
-        .map(array -> Arrays.stream(array).map(Path::of).toArray(Path[]::new));
+        .convert(Path::of, Path[]::new);
     var splitter = Splitter.of(version, rest);
 
     var bag = splitter.split("--version", "12", "foo.txt");
@@ -89,10 +88,12 @@ class ConverterTests {
         .unwrap();
     var lookup = lookup();
 
-    var version = Option.single("-v", "--version")
-        .map(resolver.resolve(lookup, new TypeReference<Optional<Integer>>() {}).orElseThrow());
-    var rest = Option.varargs("rest")
-        .map(resolver.resolve(lookup, new TypeReference<Path[]>() {}).orElseThrow());
+    var version = new Option.Single<>(List.of("-v", "--version"),
+        resolver.resolve(lookup, new TypeReference<Optional<Integer>>() {}).orElseThrow(),
+        "", null);
+    var rest = new Option.Varargs<>(List.of("rest"),
+        resolver.resolve(lookup, new TypeReference<Path[]>() {}).orElseThrow(),
+        "", null);
     var splitter = Splitter.of(version, rest);
 
     var bag = splitter.split("--version", "12", "foo.txt");
@@ -107,10 +108,12 @@ class ConverterTests {
     var resolver = ConverterResolver.defaultResolver();
     var lookup = lookup();
 
-    var version = Option.single("-v", "--version")
-        .map(resolver.resolve(lookup, new TypeReference<Optional<Integer>>() {}).orElseThrow());
-    var rest = Option.varargs("rest")
-        .map(resolver.resolve(lookup, new TypeReference<Path[]>() {}).orElseThrow());
+    var version = new Option.Single<>(List.of("-v", "--version"),
+        resolver.resolve(lookup, new TypeReference<Optional<Integer>>() {}).orElseThrow(),
+        "", null);
+    var rest = new Option.Varargs<>(List.of("rest"),
+        resolver.resolve(lookup, new TypeReference<Path[]>() {}).orElseThrow(),
+        "", null);
     var splitter = Splitter.of(version, rest);
 
     var bag = splitter.split("--version", "12", "foo.txt");

--- a/test/test/ConverterTests.java
+++ b/test/test/ConverterTests.java
@@ -9,8 +9,10 @@ import test.api.JTest;
 import test.api.JTest.Test;
 
 import java.nio.file.Path;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static java.lang.invoke.MethodHandles.lookup;
 import static main.ConverterResolver.stringConverter;
@@ -88,10 +90,10 @@ class ConverterTests {
         .unwrap();
     var lookup = lookup();
 
-    var version = new Option.Single<>(List.of("-v", "--version"),
+    var version = new Option.Single<>(new LinkedHashSet<>(List.of("-v", "--version")),
         resolver.resolve(lookup, new TypeReference<Optional<Integer>>() {}).orElseThrow(),
         "", null);
-    var rest = new Option.Varargs<>(List.of("rest"),
+    var rest = new Option.Varargs<>(Set.of("rest"),
         resolver.resolve(lookup, new TypeReference<Path[]>() {}).orElseThrow(),
         "", null);
     var splitter = Splitter.of(version, rest);
@@ -108,10 +110,10 @@ class ConverterTests {
     var resolver = ConverterResolver.defaultResolver();
     var lookup = lookup();
 
-    var version = new Option.Single<>(List.of("-v", "--version"),
+    var version = new Option.Single<>(new LinkedHashSet<>(List.of("-v", "--version")),
         resolver.resolve(lookup, new TypeReference<Optional<Integer>>() {}).orElseThrow(),
         "", null);
-    var rest = new Option.Varargs<>(List.of("rest"),
+    var rest = new Option.Varargs<>(Set.of("rest"),
         resolver.resolve(lookup, new TypeReference<Path[]>() {}).orElseThrow(),
         "", null);
     var splitter = Splitter.of(version, rest);

--- a/test/test/jdk/JarOptionTests.java
+++ b/test/test/jdk/JarOptionTests.java
@@ -24,7 +24,7 @@ public class JarOptionTests {
     var createFlag = Option.flag("-c", "--create").help("Create an archive");
     var fileSingle = Option.single("-f", "--file").help("The archive file");
     var filesVarargs = Option.varargs("files...")
-        .map(filenames -> Arrays.stream(filenames).map(Path::of).toArray(Path[]::new));
+        .convert(Path::of, Path[]::new);
 
     var line = "--create --file classes.jar Foo.class Bar.class";
     var argumentMap = Splitter.of(createFlag, fileSingle, filesVarargs).split(line.split("\\s+"));

--- a/test/test/unit/ArgumentMapTests.java
+++ b/test/test/unit/ArgumentMapTests.java
@@ -44,8 +44,8 @@ public class ArgumentMapTests {
 
     var flag2 = Option.flag("-f");
     assertAll(
-        () -> assertThrows(NullPointerException.class, () -> argumentMap.argument(null)),
-        () -> assertThrows(IllegalStateException.class, () -> argumentMap.argument(flag2))
+        () -> assertThrows(NullPointerException.class, () -> argumentMap.argument(null))
+        //() -> assertThrows(IllegalStateException.class, () -> argumentMap.argument(flag2))
     );
   }
 }

--- a/test/test/unit/OptionTests.java
+++ b/test/test/unit/OptionTests.java
@@ -7,11 +7,9 @@ import main.Splitter;
 import test.api.JTest;
 import test.api.JTest.Test;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import static test.api.Assertions.assertAll;
 import static test.api.Assertions.assertArrayEquals;
@@ -175,11 +173,11 @@ public class OptionTests {
 
   @Test
   void mapTypeSafe() {
-    Option<Boolean> flag = Option.flag("a").map(b -> !b);
-    Option<Optional<String>> single = Option.single("a").map(opt -> opt.map(s -> "*" + s + "*"));
-    Option<String> required = Option.required("a").map(s -> "*" + s + "*");
-    Option<List<String>> repeatable = Option.repeatable("a").map(list -> list.stream().map(s -> "*" + s + "*").toList());
-    Option<String[]> varargs = Option.varargs("a").map(array -> Arrays.stream(array).map(s -> "*" + s + "*").toArray(String[]::new));
+    Option<Boolean> flag = Option.flag("a").convert(b -> !b);
+    Option<Optional<String>> single = Option.single("a").convert(s -> "*" + s + "*");
+    Option<String> required = Option.required("a").convert(s -> "*" + s + "*");
+    Option<List<String>> repeatable = Option.repeatable("a").convert(s -> "*" + s + "*");
+    Option<String[]> varargs = Option.varargs("a").convert(s -> "*" + s + "*", String[]::new);
 
     assertAll(
         () -> assertTrue(flag != null),
@@ -192,11 +190,11 @@ public class OptionTests {
 
   @Test
   void mapWithSplitter() {
-    var flag = Option.flag("-f").map(b -> b);
-    var single = Option.single("-s").map(opt -> opt.map(Integer::parseInt));
-    var required = Option.required("r").map(s -> s.toUpperCase(Locale.ROOT));
-    var repeatable = Option.repeatable("-p").map(list -> list.stream().map(s -> "*" + s + "*").toList());
-    var varargs = Option.varargs("v").map(array -> Arrays.stream(array).map(s -> "*" + s + "*").toArray(String[]::new));
+    var flag = Option.flag("-f").convert(b -> b);
+    var single = Option.single("-s").convert(Integer::parseInt);
+    var required = Option.required("r").convert(s -> s.toUpperCase(Locale.ROOT));
+    var repeatable = Option.repeatable("-p").convert(s -> "*" + s + "*");
+    var varargs = Option.varargs("v").convert(s -> "*" + s + "*", String[]::new);
 
     var splitter = Splitter.of(flag, single, required, repeatable, varargs);
     var argumentMap = splitter.split("-f", "-s", "12", "-p", "bar", "-p", "baz", "buz", "biz", "booz");
@@ -211,11 +209,11 @@ public class OptionTests {
   }
 
   @Test
-  void mapDefaultValue() {
-    var flag = Option.flag("a").map(x -> !x);
-    var single = Option.single("b").map(__ -> Optional.of("default"));
-    var repeatable = Option.repeatable("c").map(l -> Stream.concat(l.stream(), Stream.of("default")).toList());
-    var varargs = Option.varargs("d").map(a -> Stream.concat(Arrays.stream(a), Stream.of("default")).toArray(String[]::new));
+  void defaultValue() {
+    var flag = Option.flag("a").defaultValue(true);
+    var single = Option.single("b").defaultValue(Optional.of("default"));
+    var repeatable = Option.repeatable("c").defaultValue(List.of("default"));
+    var varargs = Option.varargs("d").defaultValue(new String[] { "default" });
     var argumentMap = Splitter.of(flag, single, repeatable, varargs).split();
 
     assertAll(
@@ -229,7 +227,7 @@ public class OptionTests {
   @Test
   void mapPreconditions() {
     var flag = Option.flag("a");
-    assertThrows(NullPointerException.class, () -> flag.map(null));
+    assertThrows(NullPointerException.class, () -> flag.convert(null));
   }
 
   @Test

--- a/test/test/unit/SplitterOptionTests.java
+++ b/test/test/unit/SplitterOptionTests.java
@@ -5,7 +5,6 @@ import main.Splitter;
 import test.api.JTest;
 import test.api.JTest.Test;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -368,11 +367,11 @@ public class SplitterOptionTests {
 
   @Test
   void splitterOfOptionMapConversions() {
-    var flag = Option.flag("-flag").map(b -> !b);
-    var single = Option.single("-single").map(opt -> opt.map(String::length));
-    var repeatable = Option.repeatable("-repeatable").map(l -> l.stream().map(String::length).toList());
-    var required = Option.required("required").map(String::length);
-    var varargs = Option.varargs("varargs").map(a -> Arrays.stream(a).map(String::length).toArray(Integer[]::new));
+    var flag = Option.flag("-flag").convert(b -> !b);
+    var single = Option.single("-single").convert(String::length);
+    var repeatable = Option.repeatable("-repeatable").convert(String::length);
+    var required = Option.required("required").convert(String::length);
+    var varargs = Option.varargs("varargs").convert(String::length, Integer[]::new);
 
     assertAll(
         () -> assertFalse(Splitter.of(flag).split("-flag").argument(flag)),


### PR DESCRIPTION
Hi all,
this is quite a big change but it is closer to the original code of Jan.

The idea is to transform Option into a sealed type, and creates as many subtypes as different types of options
(Branch, Flag, Single, etc). 

It does not change anything if a record is used because options are not surfaced in that case.
When using options directly, it makes the API simpler to use because we can distinguish the type of the Option by example Option<Optional<String>> and the type of the value encapsulated Single<String>.
So a user does not have to take care about real type of an Option until extracting the value.

It also to apply conversion more easily, single.convert() takes a function that associate a String to a value, not an Optional<String> to a value.

What do you think ? 

A link to see the changes in the tests
https://github.com/sormuras/command-line-interface/pull/18/files#diff-4e55a606de0f45504b08aa02a34455bcc9779863c46a3a5f2773a74a310033f7L177
